### PR TITLE
Bugfix/emojis grid fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,13 +449,25 @@ getEmojis = () => {
         if (this.readyState == 4 && this.status == 200) {
             clearAllDinamicContent();
             emojis = JSON.parse(this.responseText);
-            let content = `<article class="emojis"><h2>emojis</h2><ul type="none" class="row col-12 px-0 py-3 mx-0">` ;
+            let content = `
+          <style>
+            .emoji-title {
+              text-overflow: ellipsis;
+              -webkit-line-clamp: 1;
+              overflow: hidden;
+              max-width: 100%;
+            }
+          </style>
+          <article class="emojis">
+            <h2>emojis</h2>
+            <ul type="none" class="row col-12 px-0 py-3 mx-0">
+        `;
             for (prop in emojis) {
                 content += `
             <li id="${prop}" class="col-6 col-sm-4 col-md-3 col-lg-2 my-3">
               <div class="d-flex flex-column flex-nowrap justify-content-center align-items-center p-3 bg-light border rounded-lg">
                 <img src="${emojis[prop]}" width="50" height="50"/>
-                <small class="text-center mt-3 text-black-50 font-weight-bold">${prop}</small>
+                <small class="text-center mt-3 text-black-50 font-weight-bold emoji-title">${prop}</small>
               </div>
             </li>
           `;

--- a/main.js
+++ b/main.js
@@ -83,13 +83,25 @@ window.onload = () => {
       if (this.readyState == 4 && this.status == 200) {
         clearAllDinamicContent();
         emojis = JSON.parse(this.responseText);
-        let content = `<article class="emojis"><h2>emojis</h2><ul type="none" class="row col-12 px-0 py-3 mx-0">`;
+        let content = `
+          <style>
+            .emoji-title {
+              text-overflow: ellipsis;
+              -webkit-line-clamp: 1;
+              overflow: hidden;
+              max-width: 100%;
+            }
+          </style>
+          <article class="emojis">
+            <h2>emojis</h2>
+            <ul type="none" class="row col-12 px-0 py-3 mx-0">
+        `;
         for (prop in emojis) {
           content += `
             <li id="${prop}" class="col-6 col-sm-4 col-md-3 col-lg-2 my-3">
               <div class="d-flex flex-column flex-nowrap justify-content-center align-items-center p-3 bg-light border rounded-lg">
                 <img src="${emojis[prop]}" width="50" height="50"/>
-                <small class="text-center mt-3 text-black-50 font-weight-bold">${prop}</small>
+                <small class="text-center mt-3 text-black-50 font-weight-bold emoji-title">${prop}</small>
               </div>
             </li>
           `;


### PR DESCRIPTION
Aplicando line-clamp (define máximo de linhas) e largura máxima para os títulos dos emojis, pois estavam gerando scroll horizontal no mobile (por serem um título sem espaço, transbordavam seus containers em alguns casos).